### PR TITLE
Replacing `HashMap` with `PayloadVec` type

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -23,6 +23,10 @@ pub enum RuleSetError {
     /// 3 - Incorrect account owner
     #[error("Incorrect account owner")]
     IncorrectOwner,
+
+    /// 4 - PayloadVec Index error.
+    #[error("Could not index into PayloadVec")]
+    PayloadVecIndexError,
 }
 
 impl PrintProgramError for RuleSetError {

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,11 +1,10 @@
-use crate::{payload::Payload, state::Operation};
+use crate::{state::Operation, PayloadVec};
 use borsh::{BorshDeserialize, BorshSerialize};
 use shank::ShankInstruction;
 use solana_program::{
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
 };
-use std::collections::HashMap;
 
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
@@ -24,8 +23,8 @@ pub struct ValidateArgs {
     pub name: String,
     /// `Operation` to validate.
     pub operation: Operation,
-    /// Map of `Payload` values for rule validation.
-    pub payload_map: HashMap<u8, Payload>,
+    /// Vec of `Payload` values for rule validation.
+    pub payloads: PayloadVec,
 }
 
 #[derive(Debug, Clone, ShankInstruction, BorshSerialize, BorshDeserialize)]
@@ -89,7 +88,7 @@ pub fn validate(
     ruleset_pda: Pubkey,
     name: String,
     operation: Operation,
-    payload_map: HashMap<u8, Payload>,
+    payloads: PayloadVec,
     rule_signer_accounts: Vec<Pubkey>,
     rule_nonsigner_accounts: Vec<Pubkey>,
 ) -> Instruction {
@@ -125,7 +124,7 @@ pub fn validate(
         data: RuleSetInstruction::Validate(ValidateArgs {
             name,
             operation,
-            payload_map,
+            payloads,
         })
         .try_to_vec()
         .unwrap(),

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -7,7 +7,7 @@ pub mod processor;
 pub mod state;
 pub mod utils;
 
-pub use payload::Payload;
+pub use payload::{Payload, PayloadVec};
 pub use solana_program;
 
 solana_program::declare_id!("auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg");

--- a/program/src/payload.rs
+++ b/program/src/payload.rs
@@ -1,8 +1,14 @@
+use crate::{error::RuleSetError, state::Rule};
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::pubkey::Pubkey;
 
+/// Number of variants in the Payload enum.  Must be kept up to date
+/// until `std::mem::variant_count` is stabilized.
+const NUM_PAYLOAD_VARIANTS: usize = 10;
+
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 pub enum Payload {
+    None,
     All,
     Any,
     AdditionalSigner,
@@ -21,4 +27,39 @@ pub enum Payload {
         proof: Vec<[u8; 32]>,
         leaf: [u8; 32],
     },
+}
+
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+pub struct PayloadVec {
+    payloads: Vec<Payload>,
+}
+
+impl PayloadVec {
+    pub fn new() -> Self {
+        Self {
+            payloads: vec![Payload::None; NUM_PAYLOAD_VARIANTS],
+        }
+    }
+
+    pub fn add(&mut self, rule: &Rule, payload: Payload) -> Result<(), RuleSetError> {
+        let index = rule.to_usize();
+        if index >= NUM_PAYLOAD_VARIANTS {
+            return Err(RuleSetError::PayloadVecIndexError);
+        }
+        self.payloads[index] = payload;
+        Ok(())
+    }
+
+    pub fn get(&self, rule: &Rule) -> Option<&Payload> {
+        match self.payloads.get(rule.to_usize()) {
+            Some(Payload::None) => None,
+            other => other,
+        }
+    }
+}
+
+impl Default for PayloadVec {
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -111,7 +111,7 @@ impl Processor {
                     .ok_or(RuleSetError::ErrorName)?;
 
                 // Validate the Rule.
-                if let Err(err) = rule.validate(&accounts_map, &args.payload_map) {
+                if let Err(err) = rule.validate(&accounts_map, &args.payloads) {
                     msg!("Failed to validate: {}", err);
                     return Err(err);
                 }

--- a/program/tests/integration.rs
+++ b/program/tests/integration.rs
@@ -6,10 +6,9 @@ use rmp_serde::Serializer;
 use serde::Serialize;
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, transaction::Transaction};
-use std::collections::HashMap;
 use token_authorization_rules::{
     state::{Operation, Rule, RuleSet},
-    Payload,
+    Payload, PayloadVec,
 };
 use utils::program_test;
 
@@ -33,7 +32,10 @@ async fn test_validator_transaction() {
     let amount_check = Rule::Amount { amount: 2 };
 
     // Store the payloads that represent rule-specific data.
-    let payloads_map = HashMap::from([(amount_check.to_u8(), Payload::Amount { amount: 2 })]);
+    let mut payloads = PayloadVec::new();
+    payloads
+        .add(&amount_check, Payload::Amount { amount: 2 })
+        .unwrap();
 
     let first_rule = Rule::All {
         rules: vec![adtl_signer, adtl_signer2],
@@ -86,7 +88,7 @@ async fn test_validator_transaction() {
         ruleset_addr,
         "da rulez".to_string(),
         Operation::Transfer,
-        payloads_map,
+        payloads,
         vec![],
         vec![],
     );

--- a/program/tests/utils/mod.rs
+++ b/program/tests/utils/mod.rs
@@ -2,7 +2,7 @@ use solana_program_test::ProgramTest;
 
 pub fn program_test() -> ProgramTest {
     ProgramTest::new(
-        "token-authorization-rules",
+        "token_authorization_rules",
         token_authorization_rules::id(),
         None,
     )


### PR DESCRIPTION
### Notes
* This works around a Solita SDK generation issue.
* Also abstracts initializing and indexing into the Vec from caller.
* Would use an array but causes issues with Borsh serialization.

#### IDL, SDK, and docs regenerated with this code in: https://github.com/metaplex-foundation/token-authorization-rules/pull/8

### Testing
```
cargo build-bpf
cargo test-bpf
```