### PR TITLE
Move payload construction in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,6 @@ fn main() {
     };
     let amount_check = Rule::Amount { amount: 2 };
 
-    // Store the payloads that represent rule-specific data.
-    let mut payloads = PayloadVec::new();
-    payloads
-        .add(&amount_check, Payload::Amount { amount: 2 })
-        .unwrap();
-
     let first_rule = Rule::All {
         rules: vec![adtl_signer, adtl_signer2],
     };
@@ -108,6 +102,16 @@ fn main() {
     let signature = rpc_client.send_and_confirm_transaction(&create_tx).unwrap();
 
     println!("Create tx signature: {}", signature);
+
+    // Store the payloads that represent rule-specific data that will be used for validation.
+    let mut payloads = PayloadVec::new();
+    let unused = 0;
+    payloads
+        .add(
+            &Rule::Amount { amount: unused },
+            Payload::Amount { amount: 2 },
+        )
+        .unwrap();
 
     // Create a `validate` instruction.
     let validate_ix = token_authorization_rules::instruction::validate(


### PR DESCRIPTION
Also I do see a limitation I don't like in the `PayloadVec` implementation which is basically having to define a dummy rule in order to be passed as an index.  Maybe should go back to having the user index it directly, but even then they would still have to construct a dummy rule in order to call `to_usize()` on it.  