### PR TITLE
Danenbm/basic royalty enforcement test

### DIFF
--- a/program/Cargo.lock
+++ b/program/Cargo.lock
@@ -2399,6 +2399,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpl-token-metadata"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e719d7e0b5a9d97c7fd4d6f52ebfc32f1e3942e068173e47355f8c275656488a"
+dependencies = [
+ "arrayref",
+ "borsh",
+ "mpl-token-vault",
+ "num-derive",
+ "num-traits",
+ "shank",
+ "solana-program",
+ "spl-associated-token-account",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
+name = "mpl-token-vault"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ade4ef15bc06a6033076c4ff28cba9b42521df5ec61211d6f419415ace2746a"
+dependencies = [
+ "borsh",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5932,6 +5964,7 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "borsh",
+ "mpl-token-metadata",
  "num-derive",
  "num-traits",
  "rmp-serde",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0.87"
 rmp-serde = "1.1.1"
 
 [features]
+no-entrypoint = []
 test-bpf = []
 
 [dev-dependencies]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -26,6 +26,7 @@ solana-sdk = "=1.13.5"
 solana-validator = "=1.13.5"
 solana-logger = "=1.13.5"
 spl-token = "3.5.0"
+mpl-token-metadata = "1"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/src/payload.rs
+++ b/program/src/payload.rs
@@ -12,7 +12,7 @@ pub struct LeafInfo {
     pub leaf: [u8; 32],
 }
 
-#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone, Default)]
 pub struct Payload {
     pub destination_key: Option<Pubkey>,
     pub derived_key_seeds: Option<SeedsVec>,

--- a/program/tests/basic_royalty_enforcement.rs
+++ b/program/tests/basic_royalty_enforcement.rs
@@ -1,0 +1,77 @@
+#![cfg(feature = "test-bpf")]
+
+pub mod utils;
+
+use rmp_serde::Serializer;
+use serde::Serialize;
+use solana_program_test::tokio;
+use solana_sdk::{signature::Signer, transaction::Transaction};
+use token_authorization_rules::state::{Operation, Rule, RuleSet};
+use utils::program_test;
+
+#[tokio::test]
+async fn basic_royalty_enforcement() {
+    let mut context = program_test().start_with_context().await;
+
+    // Find RuleSet PDA.
+    let (ruleset_addr, _ruleset_bump) = token_authorization_rules::pda::find_ruleset_address(
+        context.payer.pubkey(),
+        "basic_royalty_enforcement".to_string(),
+    );
+
+    // Rule for Transfers.  Initially the rule was to allow transfers to
+    // either a Token Owned Escrow OR an Identity-associated wallet.  But
+    // Identity was descoped.
+    let program_is_token_metadata = Rule::ProgramOwned {
+        program: mpl_token_metadata::id(),
+    };
+
+    let marketplace_tree_root = [0u8; 32];
+
+    // Rule for Delegate and SaleTransfer.  The provided leaf node must be a
+    // member of the marketplace Merkle tree.
+    let leaf_in_marketplace_tree = Rule::PubkeyTreeMatch {
+        root: marketplace_tree_root,
+    };
+
+    // Create Basic Royalty Enforcement Ruleset.
+    let mut basic_royalty_enforcement_rule_set = RuleSet::new();
+    basic_royalty_enforcement_rule_set.add(Operation::Transfer, program_is_token_metadata);
+    basic_royalty_enforcement_rule_set.add(Operation::Delegate, leaf_in_marketplace_tree.clone());
+    basic_royalty_enforcement_rule_set.add(Operation::SaleTransfer, leaf_in_marketplace_tree);
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&basic_royalty_enforcement_rule_set,).unwrap()
+    );
+
+    // Serialize the RuleSet using RMP serde.
+    let mut serialized_data = Vec::new();
+    basic_royalty_enforcement_rule_set
+        .serialize(&mut Serializer::new(&mut serialized_data))
+        .unwrap();
+
+    // Create a `create` instruction.
+    let create_ix = token_authorization_rules::instruction::create(
+        token_authorization_rules::id(),
+        context.payer.pubkey(),
+        ruleset_addr,
+        "basic_royalty_enforcement".to_string(),
+        serialized_data,
+    );
+
+    // Add it to a transaction.
+    let create_tx = Transaction::new_signed_with_payer(
+        &[create_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    // Process the transaction.
+    context
+        .banks_client
+        .process_transaction(create_tx)
+        .await
+        .expect("creation should succeed");
+}


### PR DESCRIPTION
Add code to test building and serializing basic royalty enforcement RuleSet.
Add `no-entrypoint` and default for Payload.